### PR TITLE
Fix PDF button label

### DIFF
--- a/pdf.html
+++ b/pdf.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <div class="top-right">
-      <button id="loadUrlButton" onclick="window.location.href='index.html'">Gdoc</button>
+      <button id="loadUrlButton" onclick="window.location.href='index.html'">GDoc</button>
     </div>
     <div class="left-pane">
       <h1>DocuTranslate</h1>


### PR DESCRIPTION
## Summary
- correct the button label in `pdf.html` from `Gdoc` to `GDoc`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68812952db58832a9441fa8373ad7c38