### PR TITLE
Add Jest tests for serverless functions

### DIFF
--- a/functions/__tests__/fetch-doc.test.js
+++ b/functions/__tests__/fetch-doc.test.js
@@ -1,0 +1,27 @@
+const nock = require('nock');
+const handler = require('../fetch-doc').handler;
+
+describe('fetch-doc handler', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('returns PDF data with statusCode 200', async () => {
+    const url = 'https://example.com/doc.pdf';
+    const pdfData = 'PDFDATA';
+
+    nock('https://example.com')
+      .get('/doc.pdf')
+      .reply(200, pdfData, {'Content-Type': 'application/pdf'});
+
+    const event = { body: JSON.stringify({ url }) };
+
+    const result = await handler(event, {});
+
+    expect(result.statusCode).toBe(200);
+    expect(result.isBase64Encoded).toBe(true);
+    const decoded = Buffer.from(result.body, 'base64').toString();
+    expect(decoded).toBe(pdfData);
+    expect(result.headers['Content-Type']).toBe('application/pdf');
+  });
+});

--- a/functions/__tests__/translate.test.js
+++ b/functions/__tests__/translate.test.js
@@ -1,0 +1,24 @@
+const nock = require('nock');
+const handler = require('../translate').handler;
+
+describe('translate handler', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('returns translation with statusCode 200', async () => {
+    process.env.DEEPL_API_KEY = 'test';
+    const responseBody = { translations: [{ text: 'Bonjour' }] };
+
+    nock('https://api-free.deepl.com')
+      .post('/v2/translate')
+      .reply(200, responseBody);
+
+    const event = { body: JSON.stringify({ text: 'Hello', target_lang: 'FR' }) };
+    const result = await handler(event, {});
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body).toEqual(responseBody);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
   "dependencies": {
     "node-fetch": "^2.6.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "nock": "^13.0.0"
+  },
   "scripts": {
-    "build": "echo 'No build step required'"
+    "build": "echo 'No build step required'",
+    "test": "jest"
   },
   "author": "Jérémy VIOLETTE",
   "license": "MIT"


### PR DESCRIPTION
## Summary
- install Jest and nock dev dependencies
- add a `test` npm script
- add tests for `fetch-doc` and `translate` handlers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812973bf50832aa16156fed5a645af